### PR TITLE
Fixed issue where it would remove too many lines form the original so…

### DIFF
--- a/Plugin/Editor/PostBuildTrigger.cs
+++ b/Plugin/Editor/PostBuildTrigger.cs
@@ -117,7 +117,7 @@ public static class PostBuildTrigger
 					newContents.Add(valuesToAppend[foundIndex] + rn);
 					found = false;
 				} else if((positionsInMethod[foundIndex] == Position.End) && line.Trim().Equals("}")) {
-					newContents = newContents.GetRange(0, newContents.Count - 3);
+					newContents = newContents.GetRange(0, newContents.Count - 1);
 					newContents.Add(valuesToAppend[foundIndex] + rn + "}" + rn);
 					found = false;
 				}


### PR DESCRIPTION
…urce instead of the trailing '}' when appending to the end of a method

this was removing the line 
[UIView setAnimationsEnabled:YES];
which was removing the onscreen keyboard open/close animations 

Hard issue to spot if your app never used UIKit :)