### PR TITLE
Fixed crash logs not automatically submitting

### DIFF
--- a/UnityPluginSources/HockeyAppUnity/HockeyAppUnity.m
+++ b/UnityPluginSources/HockeyAppUnity/HockeyAppUnity.m
@@ -20,6 +20,7 @@
   [self configAuthentificatorWithIdentificationType:authType secret:secret];
   [self configUpdateManagerWithUpdateManagerEnabled:updateManagerEnabled];
   [self configMetricsManagerWithUserMetricsEnabled:userMetricsEnabled];
+  [self configCrashManagerWithAutoSendEnabled:autoSendEnabled];
   [self startManager];
 }
 


### PR DESCRIPTION
Fixed a bug that caused the manager to never be configured to automatically submit crash logs 
