### PR TITLE
fixed Plugin/Editor/PostBuildTrigger.cs about Photos.framework.

### DIFF
--- a/Plugin/Editor/PostBuildTrigger.cs
+++ b/Plugin/Editor/PostBuildTrigger.cs
@@ -56,7 +56,6 @@ public static class PostBuildTrigger
 			proj.AddFrameworkToProject(projectTarget, "MobileCoreServices.framework", false);
 			proj.AddFrameworkToProject(projectTarget, "QuickLook.framework", false);
 			proj.AddFrameworkToProject(projectTarget, "Security.framework", false);
-			proj.AddFrameworkToProject(projectTarget, "Photos.framework", false);
 			proj.AddFrameworkToProject(projectTarget, "libz.dylib", false);
 
 			File.WriteAllText(projPath, proj.WriteToString());


### PR DESCRIPTION
because currently only ExampleGame/Assets/Editor/PostBuildTrigger.cs is fixed in https://github.com/bitstadium/HockeySDK-Unity-iOS/commit/1b00e05d789c443f4a4d638508d3c41a62c69bd7