### PR TITLE
Fix/initialization

### DIFF
--- a/Plugin/Editor/PostBuildTrigger.cs
+++ b/Plugin/Editor/PostBuildTrigger.cs
@@ -83,7 +83,7 @@ public static class PostBuildTrigger
 		string[] valuesToAppend = {CODE_UI_LOADED};
 		Position[] positionsInMethod = new Position[]{Position.End};
 
-		//InsertCodeIntoClass (filepath, methodSignatures, valuesToAppend, positionsInMethod);
+		InsertCodeIntoClass (filepath, methodSignatures, valuesToAppend, positionsInMethod);
 	}
 
 	private static void InsertCodeIntoClass(string filepath, string[] methodSignatures, string[] valuesToAppend, Position[]positionsInMethod) {

--- a/Plugin/Editor/PostBuildTrigger.cs
+++ b/Plugin/Editor/PostBuildTrigger.cs
@@ -83,7 +83,7 @@ public static class PostBuildTrigger
 		string[] valuesToAppend = {CODE_UI_LOADED};
 		Position[] positionsInMethod = new Position[]{Position.End};
 
-		InsertCodeIntoClass (filepath, methodSignatures, valuesToAppend, positionsInMethod);
+		//InsertCodeIntoClass (filepath, methodSignatures, valuesToAppend, positionsInMethod);
 	}
 
 	private static void InsertCodeIntoClass(string filepath, string[] methodSignatures, string[] valuesToAppend, Position[]positionsInMethod) {

--- a/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
+++ b/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
@@ -13,6 +13,7 @@ public class HockeyAppIOS : MonoBehaviour
 	protected const string LOG_FILE_DIR = "/logs/";
 	protected const int MAX_CHARS = 199800;
 	private static HockeyAppIOS instance;
+	private static bool gameViewLoaded;
 
 	public enum AuthenticatorType
 	{
@@ -107,6 +108,10 @@ public class HockeyAppIOS : MonoBehaviour
 	void GameViewLoaded (string message)
 	{
 		#if (UNITY_IPHONE && !UNITY_EDITOR)
+		if (gameViewLoaded) {
+			return;
+		}
+		gameViewLoaded = true;
 		string urlString = GetBaseURL();
 		string authTypeString = GetAuthenticatorTypeString();
 		HockeyApp_StartHockeyManager(appID, urlString, authTypeString, secret, updateAlert, userMetrics, autoUploadCrashes);

--- a/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
+++ b/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
@@ -79,6 +79,7 @@ public class HockeyAppIOS : MonoBehaviour
 				StartCoroutine(SendLogs(logFileDirs));
 			}
 		}
+		GameViewLoaded(null);
 		#endif
 	}
 

--- a/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
+++ b/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
@@ -68,6 +68,7 @@ public class HockeyAppIOS : MonoBehaviour
 			Destroy(gameObject);
 			return;
 		}
+		instance = this;
 
 		DontDestroyOnLoad(gameObject);
 		CreateLogDirectory();
@@ -109,7 +110,6 @@ public class HockeyAppIOS : MonoBehaviour
 		string urlString = GetBaseURL();
 		string authTypeString = GetAuthenticatorTypeString();
 		HockeyApp_StartHockeyManager(appID, urlString, authTypeString, secret, updateAlert, userMetrics, autoUploadCrashes);
-		instance = this;
 		#endif
 	}
 

--- a/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
+++ b/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
@@ -12,6 +12,7 @@ public class HockeyAppIOS : MonoBehaviour
 	protected const string HOCKEYAPP_CRASHESPATH = "api/2/apps/[APPID]/crashes/upload";
 	protected const string LOG_FILE_DIR = "/logs/";
 	protected const int MAX_CHARS = 199800;
+	private static HockeyAppIOS instance;
 
 	public enum AuthenticatorType
 	{
@@ -63,6 +64,11 @@ public class HockeyAppIOS : MonoBehaviour
 	{
 
 		#if (UNITY_IPHONE && !UNITY_EDITOR)
+		if (instance != null) {
+			Destroy(gameObject);
+			return;
+		}
+
 		DontDestroyOnLoad(gameObject);
 		CreateLogDirectory();
 
@@ -102,6 +108,7 @@ public class HockeyAppIOS : MonoBehaviour
 		string urlString = GetBaseURL();
 		string authTypeString = GetAuthenticatorTypeString();
 		HockeyApp_StartHockeyManager(appID, urlString, authTypeString, secret, updateAlert, userMetrics, autoUploadCrashes);
+		instance = this;
 		#endif
 	}
 

--- a/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
+++ b/Plugin/HockeyAppUnityIOS/HockeyAppUnity-Scripts/HockeyAppIOS.cs
@@ -13,7 +13,6 @@ public class HockeyAppIOS : MonoBehaviour
 	protected const string LOG_FILE_DIR = "/logs/";
 	protected const int MAX_CHARS = 199800;
 	private static HockeyAppIOS instance;
-	private static bool gameViewLoaded;
 
 	public enum AuthenticatorType
 	{
@@ -81,7 +80,7 @@ public class HockeyAppIOS : MonoBehaviour
 				StartCoroutine(SendLogs(logFileDirs));
 			}
 		}
-		GameViewLoaded(null);
+		StartHockeyManager();
 		#endif
 	}
 
@@ -107,11 +106,11 @@ public class HockeyAppIOS : MonoBehaviour
 
 	void GameViewLoaded (string message)
 	{
+	}
+
+	void StartHockeyManager ()
+	{
 		#if (UNITY_IPHONE && !UNITY_EDITOR)
-		if (gameViewLoaded) {
-			return;
-		}
-		gameViewLoaded = true;
 		string urlString = GetBaseURL();
 		string authTypeString = GetAuthenticatorTypeString();
 		HockeyApp_StartHockeyManager(appID, urlString, authTypeString, secret, updateAlert, userMetrics, autoUploadCrashes);


### PR DESCRIPTION
edb3e6b In the original code `instance` guard isn't utilized which is utilized in the Android version. This patch add it and also add `Destroy()` as done in https://github.com/bitstadium/HockeySDK-Unity-Android/pull/13.

eac81c8 Even though the gameObject's name was correct, I experienced the following error (cf. https://github.com/bitstadium/HockeySDK-Unity-iOS/issues/13 ):
```
SendMessage: object HockeyAppUnityIOS not found!
```
It might be caused by IL2CPP emitted code/Unity's internal implementation changes, but it is better to avoid such a timing issue. This patch avoid the issue as already done in the Android version.