### PR TITLE
Compatibility fix

### DIFF
--- a/Plugins/Editor/PostBuildTrigger.cs
+++ b/Plugins/Editor/PostBuildTrigger.cs
@@ -5,7 +5,9 @@ using System.Text;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
+#endif
 
 public static class PostBuildTrigger
 {
@@ -27,6 +29,7 @@ public static class PostBuildTrigger
 	public static void OnPostProcessBuild(BuildTarget target, string path)
 	{
 		Debug.Log( "HockeyApp Unity: Post build script starts");
+		#if UNITY_IOS
 		if (target == BuildTarget.iOS)
 		{
 			// Get target for Xcode project
@@ -57,6 +60,7 @@ public static class PostBuildTrigger
 
 			InsertCodeIntoControllerClass(path);
 		}
+		#endif
 	}
 
 	private static void InsertCodeIntoControllerClass(string projectPath) {


### PR DESCRIPTION
The usage of UnityEditor.iOS.Xcode relies upon Unity's support for building iOS having been installed.

The postbuild process for iOS is also removed when not needed.

Example of what this solves: Multiple people checkout a branch which lacks these changes. This person mostly uses Unity in the editor, and has not installed the dependencies for building iOS and Android.

This pull request fixes the situation that would arise, wherein said person would be unable to work.