### PR TITLE
Generate a proper division by zero exception

### DIFF
--- a/ExampleGame/Assets/TestUI/TestUI.cs
+++ b/ExampleGame/Assets/TestUI/TestUI.cs
@@ -26,7 +26,7 @@ public class TestUI : MonoBehaviour{
 		if(GUI.Button(GetControlRect(2), "Divide By Zero"))
 		{
 
-			int i = 0;
+			decimal i = 0;
 			i = 5 / i;
 		}
 


### PR DESCRIPTION
ObjectiveC does not trigger Division by zero exception for `NSInteger` type. We can see an exception by using `NSDecimal`. This PR will align division by zero behaviour between C# and ObjectiveC. Now the exception will be thrown.